### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "prefiks": "^0.3",
-    "stylus": "0.54.5"
+    "stylus": "0.54.8"
   },
   "devDependencies": {
     "chalk": "^1.1.1",


### PR DESCRIPTION
Update stylus to prevent  circular dependency warnings in node@15.3.0


```
(node:19927) Warning: Accessing non-existent property 'lineno' of module exports inside circular dependency
    at emitCircularRequireWarning (node:internal/modules/cjs/loader:692:11)
    at Object.get (node:internal/modules/cjs/loader:706:5)
    at Boolean.Node [as constructor] (/Users/kines/docker/ws8093/frontend/node_modules/kouto-swiss/node_modules/stylus/lib/nodes/node.js:42:23)
    at new Boolean (/Users/kines/docker/ws8093/frontend/node_modules/kouto-swiss/node_modules/stylus/lib/nodes/boolean.js:23:8)
    at Object.<anonymous> (/Users/kines/docker/ws8093/frontend/node_modules/kouto-swiss/node_modules/stylus/lib/nodes/index.js:57:16)
    at Module._compile (/Users/kines/docker/ws8093/frontend/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1131:10)
    at Module.load (node:internal/modules/cjs/loader:967:32)
    at Function.Module._load (node:internal/modules/cjs/loader:807:14)
    at Module.require (node:internal/modules/cjs/loader:991:19)`